### PR TITLE
Switch to Authorization http header for nginx on production

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::BaseController < ApplicationController
   end
 
   def authenticate_user_from_token!
-    user_token = request.headers['HTTP_AUTHENTICATION_TOKEN']
+    user_token = request.headers['HTTP_AUTHORIZATION']
     user_token ||= params[:authentication_token].presence
     @current_user = user_token && User.find_by_authentication_token(user_token)
     raise Exceptions::Unauthorized unless @current_user


### PR DESCRIPTION
Nginx invalidate `all underscores_in_headers` http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers 

Which means:

`-H "authentication_token:AUTHENTICATION_TOKEN"`has be to change to `-H "authentication-token:AUTHENTICATION_TOKEN:" instead.`

So, We are proposing using `Authorization` instead for avoiding confusing.

The curl would like the following:

`
$ curl -H "Authorization:AUTHENTICATION_TOKEN" https://xxx/api/v1/users
`
